### PR TITLE
feat(day-10): VPC with Public & Private Subnets, NAT

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -14,31 +14,52 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        directory: 
+        directory:
           - infra/terraform/envs/dev
           - infra/terraform/modules/networking
-        # Adding more directories (environments/modules) to this list as needed
+        # Add more directories (environments/modules) to this list as needed
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.6.0
+
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v5
+
+      - name: Install tfsec
+        run: |
+          curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
+
       - name: Terraform Fmt Check (${{ matrix.directory }})
         working-directory: ${{ matrix.directory }}
         run: terraform fmt -check -recursive
+
       - name: Terraform Init (${{ matrix.directory }})
         working-directory: ${{ matrix.directory }}
         run: terraform init -backend=false -input=false
+
       - name: Terraform Validate (${{ matrix.directory }})
         working-directory: ${{ matrix.directory }}
         run: terraform validate
+
       - name: TFLint (${{ matrix.directory }})
         working-directory: ${{ matrix.directory }}
         run: |
           tflint --init 
           tflint
-      # Optionally, add tfsec or other security scanners here in the future
+
+      - name: tfsec Security Scan (${{ matrix.directory }})
+        working-directory: ${{ matrix.directory }}
+        run: tfsec --no-color --format sarif --out tfsec.sarif .
+
+      - name: Upload tfsec SARIF (${{ matrix.directory }})
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ matrix.directory }}/tfsec.sarif

--- a/infra/terraform/envs/dev/main.tf
+++ b/infra/terraform/envs/dev/main.tf
@@ -2,8 +2,8 @@
 # File: infra/terraform/envs/dev/main.tf
 #######################
 
-# Terraform configuration for the "dev" environment. 
-# This sets up the AWS provider (using region and profile) and calls the networking module.
+# Terraform configuration for the "dev" environment.
+# Sets up the AWS provider (region and profile) and calls the networking module with environment-specific settings.
 
 terraform {
   required_version = ">= 1.6.0, < 2.0.0"
@@ -29,10 +29,11 @@ provider "aws" {
   }
 }
 
-# Use the networking module to provision VPC and networking components for this environment.
+# Invoke the networking module to provision the VPC, subnets (public & private), and related network components for this environment.
 module "networking" {
-  source              = "../../modules/networking"
-  environment         = var.environment
-  vpc_cidr            = var.vpc_cidr
-  public_subnet_cidrs = var.public_subnet_cidrs
+  source               = "../../modules/networking"
+  environment          = var.environment
+  vpc_cidr             = var.vpc_cidr
+  public_subnet_cidrs  = var.public_subnet_cidrs
+  private_subnet_cidrs = var.private_subnet_cidrs
 }

--- a/infra/terraform/envs/dev/outputs.tf
+++ b/infra/terraform/envs/dev/outputs.tf
@@ -23,3 +23,23 @@ output "igw_id" {
   description = "ID of the Internet Gateway for the dev VPC."
   value       = module.networking.igw_id
 }
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets in the dev VPC."
+  value       = module.networking.private_subnet_ids
+}
+
+output "private_route_table_id" {
+  description = "ID of the private route table for the dev VPC (for private subnets)."
+  value       = module.networking.private_route_table_id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT Gateway providing internet egress for private subnets."
+  value       = module.networking.nat_gateway_id
+}
+
+output "nat_gateway_eip" {
+  description = "Public Elastic IP address of the NAT Gateway."
+  value       = module.networking.nat_gateway_eip
+}

--- a/infra/terraform/envs/dev/variables.tf
+++ b/infra/terraform/envs/dev/variables.tf
@@ -33,3 +33,9 @@ variable "public_subnet_cidrs" {
   type        = list(string)
   default     = ["10.0.1.0/24", "10.0.2.0/24"]
 }
+
+variable "private_subnet_cidrs" {
+  description = "CIDR blocks for the private subnets."
+  type        = list(string)
+  default     = ["10.0.11.0/24", "10.0.12.0/24"]
+}

--- a/infra/terraform/modules/networking/outputs.tf
+++ b/infra/terraform/modules/networking/outputs.tf
@@ -2,7 +2,7 @@
 # File: infra/terraform/modules/networking/outputs.tf
 ##########################
 
-# Output values from the networking module (to be used by root modules/environments).
+# Output values from the networking module (to be used by environment configurations).
 
 output "vpc_id" {
   description = "The ID of the created VPC."
@@ -22,4 +22,24 @@ output "public_route_table_id" {
 output "igw_id" {
   description = "The ID of the Internet Gateway for the VPC."
   value       = aws_internet_gateway.gw.id
+}
+
+output "private_subnet_ids" {
+  description = "The IDs of the private subnets created in the VPC (if any)."
+  value       = aws_subnet.private[*].id
+}
+
+output "private_route_table_id" {
+  description = "The ID of the private route table (for private subnets, if created)."
+  value       = length(aws_route_table.private) > 0 ? aws_route_table.private[0].id : null
+}
+
+output "nat_gateway_id" {
+  description = "The ID of the NAT Gateway (if private subnets are configured)."
+  value       = length(aws_nat_gateway.nat) > 0 ? aws_nat_gateway.nat[0].id : null
+}
+
+output "nat_gateway_eip" {
+  description = "The Elastic IP address allocated to the NAT Gateway (if any)."
+  value       = length(aws_eip.nat) > 0 ? aws_eip.nat[0].public_ip : null
 }

--- a/infra/terraform/modules/networking/variables.tf
+++ b/infra/terraform/modules/networking/variables.tf
@@ -16,7 +16,13 @@ variable "vpc_cidr" {
 }
 
 variable "public_subnet_cidrs" {
-  description = "List of CIDR blocks for public subnets. Should contain exactly two values for two subnets."
+  description = "List of CIDR blocks for public subnets (one per AZ, e.g., two for 2 AZs)."
   type        = list(string)
   default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets. If provided, a NAT Gateway is created for egress. Defaults to empty (no private subnets)."
+  type        = list(string)
+  default     = []
 }

--- a/journal/day-10-vpc-subnets.md
+++ b/journal/day-10-vpc-subnets.md
@@ -1,0 +1,114 @@
+# Day 10 – Networking with Terraform (VPC, Public & Private Subnets, NAT Gateway) 🌐
+
+**Date:** 2025-09-02
+**Day Branch:** `day-10-vpc-subnets`
+**Topic:** Provisioning AWS networking with Terraform: VPC, subnets, Internet Gateway, route tables, and NAT gateway.
+
+---
+
+## 🎯 Goals
+
+* [x] Expand the Terraform `networking` module to include **private subnets**.
+* [x] Implement a **single cost-effective NAT gateway** for private subnet internet access.
+* [x] Reuse existing **public subnets** from Day 9.
+* [x] Configure route tables to link public → IGW and private → NAT.
+* [x] Tag resources consistently for **FinOps** and easy identification.
+* [x] Update CI workflow to validate the extended configuration.
+
+---
+
+## ✅ What I Did
+
+1. **Updated Networking Module (`modules/networking/`)**
+
+   * Added Terraform resources for two **private subnets** (`10.0.11.0/24` and `10.0.12.0/24`).
+   * Created one **NAT Gateway** inside the first public subnet.
+   * Defined a private route table pointing traffic (`0.0.0.0/0`) to the NAT.
+   * Associated private subnets with the new private route table.
+   * Reused public subnets + IGW setup from Day 9.
+
+2. **Environment Code (`envs/dev/`)**
+
+   * Called the updated networking module with variables for CIDRs, subnets, and tags.
+   * Verified remote state backend still worked (S3 + DynamoDB lock).
+
+3. **CI Workflow (`.github/workflows/terraform-ci.yml`)**
+
+   * Extended the Terraform CI pipeline to validate the new networking resources.
+   * Ran `terraform fmt`, `terraform validate`, and `tflint` to enforce standards.
+   * Ensured PR checks catch misconfigurations before applying.
+
+---
+
+## 📚 Key Concepts I Learned
+
+* **NAT Gateway vs. Internet Gateway**:
+
+  * IGW is for public subnets (resources directly reachable from internet).
+  * NAT lets private subnets initiate outbound traffic (like downloading updates) but blocks inbound.
+
+* **Subnet Types**:
+
+  * Public = `map_public_ip_on_launch = true` + route to IGW.
+  * Private = no public IPs, route via NAT gateway.
+
+* **Single NAT Tradeoff**:
+
+  * Cheaper than HA NATs, but if the AZ with NAT fails, private subnet traffic fails too.
+  * Acceptable for dev environments; prod usually uses 2+ NATs.
+
+* **Terraform Design**:
+
+  * Modules = reusable blocks for networking, compute, etc.
+  * Envs (`dev`, `prod`) call modules with different vars.
+
+---
+
+## 🛠 Commands I Ran
+
+```bash
+# Format and validate Terraform code
+terraform fmt -recursive
+terraform validate
+
+# Initialize and pull backend state (S3 + DynamoDB lock)
+terraform init
+
+# Preview changes
+terraform plan -var-file=envs/dev/terraform.tfvars
+
+# Apply changes to AWS
+terraform apply -var-file=envs/dev/terraform.tfvars
+
+# CI runs automatically on push
+gh pr create --title "Day 10 – VPC with Public & Private Subnets, NAT" --body "Networking expansion with NAT support"
+```
+
+---
+
+## ✅ Achievements
+
+* Working **VPC with public and private subnets**.
+* **Internet access enabled** in private subnets via NAT gateway.
+* Extended CI workflow to cover networking.
+* All resources tagged consistently for cost tracking.
+
+---
+
+## 🤔 Reflections
+
+* Networking feels like “plumbing” for AWS — it’s invisible but critical.
+* NAT gateways can get expensive if you add one per AZ, so designing wisely is part of DevOps maturity.
+* With Day 10 done, my infra is now **production-like** (split public/private).
+
+---
+
+## 🔮 Next Steps (Day 11 Preview)
+
+* Provision a **PostgreSQL RDS instance** inside the private subnets.
+* Add **security groups** to restrict DB access.
+* Explore **Secrets Manager** for credential handling.
+
+---
+
+⚡ *By Day 10, I’ve built a secure network foundation in AWS with Terraform — a big step toward real-world infra readiness.*


### PR DESCRIPTION
# Day 10 – Networking with Terraform (VPC, Public & Private Subnets, NAT Gateway) 🌐

**Date:** 2025-09-02
**Day Branch:** `day-10-vpc-subnets`
**Topic:** Provisioning AWS networking with Terraform: VPC, subnets, Internet Gateway, route tables, and NAT gateway.

---

## 🎯 Goals

* [x] Expand the Terraform `networking` module to include **private subnets**.
* [x] Implement a **single cost-effective NAT gateway** for private subnet internet access.
* [x] Reuse existing **public subnets** from Day 9.
* [x] Configure route tables to link public → IGW and private → NAT.
* [x] Tag resources consistently for **FinOps** and easy identification.
* [x] Update CI workflow to validate the extended configuration.

---

## ✅ What I Did

1. **Updated Networking Module (`modules/networking/`)**

   * Added Terraform resources for two **private subnets** (`10.0.11.0/24` and `10.0.12.0/24`).
   * Created one **NAT Gateway** inside the first public subnet.
   * Defined a private route table pointing traffic (`0.0.0.0/0`) to the NAT.
   * Associated private subnets with the new private route table.
   * Reused public subnets + IGW setup from Day 9.

2. **Environment Code (`envs/dev/`)**

   * Called the updated networking module with variables for CIDRs, subnets, and tags.
   * Verified remote state backend still worked (S3 + DynamoDB lock).

3. **CI Workflow (`.github/workflows/terraform-ci.yml`)**

   * Extended the Terraform CI pipeline to validate the new networking resources.
   * Ran `terraform fmt`, `terraform validate`, and `tflint` to enforce standards.
   * Ensured PR checks catch misconfigurations before applying.

---

## 📚 Key Concepts I Learned

* **NAT Gateway vs. Internet Gateway**:

  * IGW is for public subnets (resources directly reachable from internet).
  * NAT lets private subnets initiate outbound traffic (like downloading updates) but blocks inbound.

* **Subnet Types**:

  * Public = `map_public_ip_on_launch = true` + route to IGW.
  * Private = no public IPs, route via NAT gateway.

* **Single NAT Tradeoff**:

  * Cheaper than HA NATs, but if the AZ with NAT fails, private subnet traffic fails too.
  * Acceptable for dev environments; prod usually uses 2+ NATs.

* **Terraform Design**:

  * Modules = reusable blocks for networking, compute, etc.
  * Envs (`dev`, `prod`) call modules with different vars.

---

## 🛠 Commands I Ran

```bash
# Format and validate Terraform code
terraform fmt -recursive
terraform validate

# Initialize and pull backend state (S3 + DynamoDB lock)
terraform init

# Preview changes
terraform plan -var-file=envs/dev/terraform.tfvars

# Apply changes to AWS
terraform apply -var-file=envs/dev/terraform.tfvars

# CI runs automatically on push
gh pr create --title "Day 10 – VPC with Public & Private Subnets, NAT" --body "Networking expansion with NAT support"
```

---

## ✅ Achievements

* Working **VPC with public and private subnets**.
* **Internet access enabled** in private subnets via NAT gateway.
* Extended CI workflow to cover networking.
* All resources tagged consistently for cost tracking.

---

## 🤔 Reflections

* Networking feels like “plumbing” for AWS — it’s invisible but critical.
* NAT gateways can get expensive if you add one per AZ, so designing wisely is part of DevOps maturity.
* With Day 10 done, my infra is now **production-like** (split public/private).

---

## 🔮 Next Steps (Day 11 Preview)

* Provision a **PostgreSQL RDS instance** inside the private subnets.
* Add **security groups** to restrict DB access.
* Explore **Secrets Manager** for credential handling.

---

⚡ *By Day 10, I’ve built a secure network foundation in AWS with Terraform — a big step toward real-world infra readiness.*
